### PR TITLE
Update control plane image base to Alpine 3.23

### DIFF
--- a/hack/Dockerfile
+++ b/hack/Dockerfile
@@ -1,5 +1,5 @@
 # Final Alpine-based image
-FROM alpine:3.18
+FROM alpine:3.23
 ARG TARGETARCH
 
 LABEL maintainer="Loft Labs Inc <support@loft.sh>"


### PR DESCRIPTION
Fixes #22

## Summary
- update the control plane image base from `alpine:3.18` to `alpine:3.23`

## Validation
- built `hack/Dockerfile` locally with a minimal synthetic build context and `TARGETARCH=amd64`