### PR TITLE
chore(fips): bump go version for k8s 1.36 to go 1.26

### DIFF
--- a/fips/base-images/Dockerfile.etcd
+++ b/fips/base-images/Dockerfile.etcd
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.25
+ARG GO_VERSION=1.26
 FROM docker.io/library/golang:${GO_VERSION}-bookworm AS build
 
 RUN apt-get update -y && \

--- a/fips/base-images/Dockerfile.helm
+++ b/fips/base-images/Dockerfile.helm
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.25
+ARG GO_VERSION=1.26
 FROM docker.io/library/golang:${GO_VERSION}-bookworm AS build
 
 RUN apt-get update -y && \

--- a/fips/base-images/Dockerfile.k8s-full
+++ b/fips/base-images/Dockerfile.k8s-full
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.25
+ARG GO_VERSION=1.26
 FROM docker.io/library/golang:${GO_VERSION}-bookworm AS build
 
 ARG KUBERNETES_VERSION=v1.33.0
@@ -46,7 +46,7 @@ RUN \
 
 
 FROM docker.io/library/golang:${GO_VERSION}-bookworm AS build-cni-plugins
-ARG GO_VERSION=1.25
+ARG GO_VERSION=1.26
 ARG CNI_PLUGINS_VERSION=v1.8.0
 ARG CNI_META_PLUGINS="bandwidth firewall portmap"
 ARG CNI_MAIN_PLUGINS="bridge loopback"
@@ -98,7 +98,7 @@ RUN set -ex; \
 
 
 FROM docker.io/library/golang:${GO_VERSION}-bookworm AS build-runc
-ARG GO_VERSION=1.25
+ARG GO_VERSION=1.26
 ARG RUNC_VERSION=v1.3.3
 
 RUN apt-get update -y && \
@@ -135,7 +135,7 @@ RUN \
 
 
 FROM docker.io/library/golang:${GO_VERSION}-bookworm AS build-containerd
-ARG GO_VERSION=1.25
+ARG GO_VERSION=1.26
 ARG CONTAINERD_VERSION=2.1.4
 
 

--- a/fips/base-images/Dockerfile.kine
+++ b/fips/base-images/Dockerfile.kine
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.25
+ARG GO_VERSION=1.26
 FROM docker.io/library/golang:${GO_VERSION}-bookworm AS build
 
 RUN apt-get update -y && \

--- a/fips/base-images/Dockerfile.konnectivity-server
+++ b/fips/base-images/Dockerfile.konnectivity-server
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.25
+ARG GO_VERSION=1.26
 FROM docker.io/library/golang:${GO_VERSION}-bookworm AS build
 
 RUN apt-get update -y && \


### PR DESCRIPTION
## Summary

- Bumps \`ARG GO_VERSION\` from 1.25 → 1.26 across all five FIPS base-image Dockerfiles in \`fips/base-images/\`.
- Unblocks the daily \`release_fips.yaml\` cron, which has been failing since 2026-04-17 once v1.36.0 entered the upstream release matrix.

## Why

Kubernetes 1.36 requires Go >= 1.26. The current build fails with:

\`\`\`
Detected go version: go version go1.25.9 linux/amd64.
Kubernetes requires go1.26 or greater.
Please install go1.26 or later.
\`\`\`

All other FIPS sub-component images for v1.36 (etcd v3.6.10, kine v0.14.10, helm v3.19.0, konnectivity v0.34.0) already built successfully on Go 1.25 and are cached on GHCR; they will be skipped on the next cron run. The only thing currently missing is \`kubernetes:v1.36.0-fips\` / \`kubernetes:v1.36.0-fips-full\`. Bumping all five Dockerfiles keeps the toolchain consistent for any future \`force=true\` rebuild.

## Test plan

- [ ] Verify \`golang:1.26-bookworm\` is available on Docker Hub
- [ ] After merge, manually trigger \`release_fips.yaml\` to backfill v1.36.0
- [ ] Confirm \`ghcr.io/loft-sh/kubernetes:v1.36.0-fips\` and \`-fips-full\` images are pushed
- [ ] Watch first run for runc / containerd / CNI plugin build stages — these compile fine on 1.25 today, so 1.26 should be safe but worth eyeballing

Refs: [ENGCP-228](https://linear.app/loft/issue/ENGCP-228/fips-compliance)

🤖 Generated with [Claude Code](https://claude.com/claude-code)